### PR TITLE
Add Claude Code settings and expand XML schema types

### DIFF
--- a/.claude/commands/commit-message.md
+++ b/.claude/commands/commit-message.md
@@ -1,0 +1,7 @@
+Generate commit message in English from git diff.
+
+- First line should be summary of changes.
+- Details follow after a empty line.
+  - Do not quote with code block.
+  - Response without AI signature
+  - Markdown format

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:laws.e-gov.go.jp)",
+      "Bash(curl:*)",
+      "Bash(go test:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/demo/go.mod
+++ b/demo/go.mod
@@ -1,7 +1,7 @@
-module github.com/ngs/go-jplaw-xml/demo
+module go.ngs.io/jp-law-xml/demo
 
 go 1.23.6
 
-replace github.com/ngs/go-jplaw-xml => ..
+replace go.ngs.io/jp-law-xml => ..
 
-require github.com/ngs/go-jplaw-xml v0.0.0-00010101000000-000000000000
+require go.ngs.io/jp-law-xml v0.0.0-00010101000000-000000000000

--- a/demo/main.go
+++ b/demo/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/ngs/go-jplaw-xml"
+	"go.ngs.io/jp-law-xml"
 )
 
 func main() {
@@ -29,15 +29,19 @@ func main() {
 	}
 
 	log.Println("LawNum:", schema.LawNum)
-	log.Println("LawTitle:", schema.LawBody.LawTitle.CharData)
+	if schema.LawBody.LawTitle != nil {
+		log.Println("LawTitle:", schema.LawBody.LawTitle.Content)
+	}
 	for _, chapter := range schema.LawBody.MainProvision.Chapter {
-		log.Println("  Chapter:", chapter.ChapterTitle)
+		log.Println("  Chapter:", chapter.ChapterTitle.Content)
 		for _, article := range chapter.Article {
-			log.Println("    Article:", article.ArticleTitle)
+			if article.ArticleTitle != nil {
+				log.Println("    Article:", article.ArticleTitle.Content)
+			}
 			for _, paragraph := range article.Paragraph {
-				log.Println("     Paragraph:", paragraph.ParagraphNum)
+				log.Println("     Paragraph:", paragraph.ParagraphNum.Content)
 				for _, sentence := range paragraph.ParagraphSentence.Sentence {
-					log.Println("      Sentence:", sentence.CharData)
+					log.Println("      Sentence:", sentence.Content)
 				}
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ngs/go-jplaw-xml
+module go.ngs.io/jp-law-xml
 
 go 1.23.6

--- a/schema.go
+++ b/schema.go
@@ -1,357 +1,1233 @@
 package jplaw
 
+import "encoding/xml"
+
+// Law represents the root element of a Japanese law document
 type Law struct {
+	XMLName         xml.Name `xml:"Law"`
 	Era             Era      `xml:"Era,attr"`
 	Year            int      `xml:"Year,attr"`
 	Num             string   `xml:"Num,attr"`
-	PromulgateMonth int      `xml:"PromulgateMonth,attr"`
-	PromulgateDay   int      `xml:"PromulgateDay,attr"`
+	PromulgateMonth int      `xml:"PromulgateMonth,attr,omitempty"`
+	PromulgateDay   int      `xml:"PromulgateDay,attr,omitempty"`
 	LawType         LawType  `xml:"LawType,attr"`
 	Lang            Language `xml:"Lang,attr"`
-	LawBody         struct {
-		AppdxTable struct {
-			Num             string `xml:"Num,attr"`
-			AppdxTableTitle struct {
-				WritingMode string `xml:"WritingMode,attr"`
-				CharData    string `xml:",chardata"`
-			} `xml:"AppdxTableTitle"`
-			RelatedArticleNum string `xml:"RelatedArticleNum"`
-			TableStruct       struct {
-				Table struct {
-					WritingMode string `xml:"WritingMode,attr"`
-					TableRow    []struct {
-						TableColumn []struct {
-							BorderBottom string `xml:"BorderBottom,attr"`
-							BorderLeft   string `xml:"BorderLeft,attr"`
-							BorderRight  string `xml:"BorderRight,attr"`
-							BorderTop    string `xml:"BorderTop,attr"`
-							Sentence     []struct {
-								Num         string `xml:"Num,attr"`
-								WritingMode string `xml:"WritingMode,attr"`
-								CharData    string `xml:",chardata"`
-							} `xml:"Sentence"`
-						} `xml:"TableColumn"`
-					} `xml:"TableRow"`
-				} `xml:"Table"`
-			} `xml:"TableStruct"`
-		} `xml:"AppdxTable"`
-		LawTitle struct {
-			Abbrev     string `xml:"Abbrev,attr"`
-			AbbrevKana string `xml:"AbbrevKana,attr"`
-			Kana       string `xml:"Kana,attr"`
-			CharData   string `xml:",chardata"`
-		} `xml:"LawTitle"`
-		MainProvision struct {
-			Chapter []struct {
-				Num     string `xml:"Num,attr"`
-				Article []struct {
-					Num            string `xml:"Num,attr"`
-					ArticleCaption *struct {
-						CharData string `xml:",chardata"`
-						Ruby     []struct {
-							CharData string `xml:",chardata"`
-							Rt       string `xml:"Rt"`
-						} `xml:"Ruby"`
-					} `xml:"ArticleCaption"`
-					ArticleTitle string `xml:"ArticleTitle"`
-					Paragraph    []struct {
-						Num  string `xml:"Num,attr"`
-						Item []struct {
-							Num          float64 `xml:"Num,attr"`
-							ItemSentence struct {
-								Column []struct {
-									Num      string `xml:"Num,attr"`
-									Sentence struct {
-										Num         string `xml:"Num,attr"`
-										WritingMode string `xml:"WritingMode,attr"`
-										CharData    string `xml:",chardata"`
-									} `xml:"Sentence"`
-								} `xml:"Column"`
-								Sentence *struct {
-									Num         string `xml:"Num,attr"`
-									WritingMode string `xml:"WritingMode,attr"`
-									CharData    string `xml:",chardata"`
-								} `xml:"Sentence"`
-							} `xml:"ItemSentence"`
-							ItemTitle string `xml:"ItemTitle"`
-							Subitem1  []struct {
-								Num              string `xml:"Num,attr"`
-								Subitem1Sentence struct {
-									Sentence struct {
-										Num         string `xml:"Num,attr"`
-										WritingMode string `xml:"WritingMode,attr"`
-										CharData    string `xml:",chardata"`
-										Ruby        *struct {
-											CharData string `xml:",chardata"`
-											Rt       string `xml:"Rt"`
-										} `xml:"Ruby"`
-									} `xml:"Sentence"`
-								} `xml:"Subitem1Sentence"`
-								Subitem1Title string `xml:"Subitem1Title"`
-							} `xml:"Subitem1"`
-						} `xml:"Item"`
-						List []struct {
-							ListSentence struct {
-								Sentence struct {
-									Num         string `xml:"Num,attr"`
-									WritingMode string `xml:"WritingMode,attr"`
-									CharData    string `xml:",chardata"`
-								} `xml:"Sentence"`
-							} `xml:"ListSentence"`
-						} `xml:"List"`
-						ParagraphNum      string `xml:"ParagraphNum"`
-						ParagraphSentence struct {
-							Sentence []struct {
-								Function    *string `xml:"Function,attr"`
-								Num         string  `xml:"Num,attr"`
-								WritingMode string  `xml:"WritingMode,attr"`
-								CharData    string  `xml:",chardata"`
-								Ruby        []struct {
-									CharData string `xml:",chardata"`
-									Rt       string `xml:"Rt"`
-								} `xml:"Ruby"`
-							} `xml:"Sentence"`
-						} `xml:"ParagraphSentence"`
-						TableStruct *struct {
-							Table struct {
-								WritingMode string `xml:"WritingMode,attr"`
-								TableRow    []struct {
-									TableColumn []struct {
-										BorderBottom string `xml:"BorderBottom,attr"`
-										BorderLeft   string `xml:"BorderLeft,attr"`
-										BorderRight  string `xml:"BorderRight,attr"`
-										BorderTop    string `xml:"BorderTop,attr"`
-										Sentence     []struct {
-											Num         string `xml:"Num,attr"`
-											WritingMode string `xml:"WritingMode,attr"`
-											CharData    string `xml:",chardata"`
-										} `xml:"Sentence"`
-									} `xml:"TableColumn"`
-								} `xml:"TableRow"`
-							} `xml:"Table"`
-						} `xml:"TableStruct"`
-					} `xml:"Paragraph"`
-				} `xml:"Article"`
-				ChapterTitle string `xml:"ChapterTitle"`
-				Section      []struct {
-					Num     string `xml:"Num,attr"`
-					Article []struct {
-						Num            float64 `xml:"Num,attr"`
-						ArticleCaption *string `xml:"ArticleCaption"`
-						ArticleTitle   string  `xml:"ArticleTitle"`
-						Paragraph      []struct {
-							Num  string `xml:"Num,attr"`
-							Item []struct {
-								Num          string `xml:"Num,attr"`
-								ItemSentence struct {
-									Sentence struct {
-										Num         string `xml:"Num,attr"`
-										WritingMode string `xml:"WritingMode,attr"`
-										CharData    string `xml:",chardata"`
-									} `xml:"Sentence"`
-								} `xml:"ItemSentence"`
-								ItemTitle string `xml:"ItemTitle"`
-							} `xml:"Item"`
-							ParagraphNum      string `xml:"ParagraphNum"`
-							ParagraphSentence struct {
-								Sentence []struct {
-									Function    *string `xml:"Function,attr"`
-									Num         string  `xml:"Num,attr"`
-									WritingMode string  `xml:"WritingMode,attr"`
-									CharData    string  `xml:",chardata"`
-								} `xml:"Sentence"`
-							} `xml:"ParagraphSentence"`
-						} `xml:"Paragraph"`
-					} `xml:"Article"`
-					SectionTitle string `xml:"SectionTitle"`
-					Subsection   []struct {
-						Num     string `xml:"Num,attr"`
-						Article []struct {
-							Num            float64 `xml:"Num,attr"`
-							ArticleCaption string  `xml:"ArticleCaption"`
-							ArticleTitle   string  `xml:"ArticleTitle"`
-							Paragraph      []struct {
-								Num  string `xml:"Num,attr"`
-								Item []struct {
-									Num          string `xml:"Num,attr"`
-									ItemSentence struct {
-										Column []struct {
-											Num      string `xml:"Num,attr"`
-											Sentence struct {
-												Num         string `xml:"Num,attr"`
-												WritingMode string `xml:"WritingMode,attr"`
-												CharData    string `xml:",chardata"`
-											} `xml:"Sentence"`
-										} `xml:"Column"`
-										Sentence *struct {
-											Num         string `xml:"Num,attr"`
-											WritingMode string `xml:"WritingMode,attr"`
-											CharData    string `xml:",chardata"`
-										} `xml:"Sentence"`
-									} `xml:"ItemSentence"`
-									ItemTitle string `xml:"ItemTitle"`
-									Subitem1  []struct {
-										Num              string `xml:"Num,attr"`
-										Subitem1Sentence struct {
-											Sentence struct {
-												Num         string `xml:"Num,attr"`
-												WritingMode string `xml:"WritingMode,attr"`
-												CharData    string `xml:",chardata"`
-											} `xml:"Sentence"`
-										} `xml:"Subitem1Sentence"`
-										Subitem1Title string `xml:"Subitem1Title"`
-									} `xml:"Subitem1"`
-								} `xml:"Item"`
-								ParagraphNum      string `xml:"ParagraphNum"`
-								ParagraphSentence struct {
-									Sentence []struct {
-										Function    *string `xml:"Function,attr"`
-										Num         string  `xml:"Num,attr"`
-										WritingMode string  `xml:"WritingMode,attr"`
-										CharData    string  `xml:",chardata"`
-									} `xml:"Sentence"`
-								} `xml:"ParagraphSentence"`
-								TableStruct *struct {
-									Table struct {
-										WritingMode string `xml:"WritingMode,attr"`
-										TableRow    []struct {
-											TableColumn []struct {
-												BorderBottom string `xml:"BorderBottom,attr"`
-												BorderLeft   string `xml:"BorderLeft,attr"`
-												BorderRight  string `xml:"BorderRight,attr"`
-												BorderTop    string `xml:"BorderTop,attr"`
-												Sentence     []struct {
-													Num         string `xml:"Num,attr"`
-													WritingMode string `xml:"WritingMode,attr"`
-													CharData    string `xml:",chardata"`
-												} `xml:"Sentence"`
-											} `xml:"TableColumn"`
-										} `xml:"TableRow"`
-									} `xml:"Table"`
-								} `xml:"TableStruct"`
-							} `xml:"Paragraph"`
-						} `xml:"Article"`
-						SubsectionTitle string `xml:"SubsectionTitle"`
-					} `xml:"Subsection"`
-				} `xml:"Section"`
-			} `xml:"Chapter"`
-		} `xml:"MainProvision"`
-		SupplProvision []struct {
-			AmendLawNum string `xml:"AmendLawNum,attr"`
-			Extract     *bool  `xml:"Extract,attr"`
-			Article     []struct {
-				Num            string  `xml:"Num,attr"`
-				ArticleCaption *string `xml:"ArticleCaption"`
-				ArticleTitle   string  `xml:"ArticleTitle"`
-				Paragraph      []struct {
-					Num  string `xml:"Num,attr"`
-					Item []struct {
-						Num          string `xml:"Num,attr"`
-						ItemSentence struct {
-							Column []struct {
-								Num      string `xml:"Num,attr"`
-								Sentence struct {
-									Num         string `xml:"Num,attr"`
-									WritingMode string `xml:"WritingMode,attr"`
-									CharData    string `xml:",chardata"`
-								} `xml:"Sentence"`
-							} `xml:"Column"`
-							Sentence *struct {
-								Num         string `xml:"Num,attr"`
-								WritingMode string `xml:"WritingMode,attr"`
-								CharData    string `xml:",chardata"`
-							} `xml:"Sentence"`
-						} `xml:"ItemSentence"`
-						ItemTitle string `xml:"ItemTitle"`
-					} `xml:"Item"`
-					ParagraphNum      string `xml:"ParagraphNum"`
-					ParagraphSentence struct {
-						Sentence []struct {
-							Function    *string `xml:"Function,attr"`
-							Num         string  `xml:"Num,attr"`
-							WritingMode string  `xml:"WritingMode,attr"`
-							CharData    string  `xml:",chardata"`
-						} `xml:"Sentence"`
-					} `xml:"ParagraphSentence"`
-					TableStruct *struct {
-						Table struct {
-							WritingMode string `xml:"WritingMode,attr"`
-							TableRow    []struct {
-								TableColumn []struct {
-									BorderBottom string `xml:"BorderBottom,attr"`
-									BorderLeft   string `xml:"BorderLeft,attr"`
-									BorderRight  string `xml:"BorderRight,attr"`
-									BorderTop    string `xml:"BorderTop,attr"`
-									Sentence     []struct {
-										Num         string `xml:"Num,attr"`
-										WritingMode string `xml:"WritingMode,attr"`
-										CharData    string `xml:",chardata"`
-									} `xml:"Sentence"`
-								} `xml:"TableColumn"`
-							} `xml:"TableRow"`
-						} `xml:"Table"`
-					} `xml:"TableStruct"`
-				} `xml:"Paragraph"`
-			} `xml:"Article"`
-			Paragraph []struct {
-				Num  string `xml:"Num,attr"`
-				Item []struct {
-					Num          string `xml:"Num,attr"`
-					ItemSentence struct {
-						Column []struct {
-							Num      string `xml:"Num,attr"`
-							Sentence struct {
-								Num         string `xml:"Num,attr"`
-								WritingMode string `xml:"WritingMode,attr"`
-								CharData    string `xml:",chardata"`
-							} `xml:"Sentence"`
-						} `xml:"Column"`
-						Sentence *struct {
-							Num         string `xml:"Num,attr"`
-							WritingMode string `xml:"WritingMode,attr"`
-							CharData    string `xml:",chardata"`
-						} `xml:"Sentence"`
-					} `xml:"ItemSentence"`
-					ItemTitle string `xml:"ItemTitle"`
-				} `xml:"Item"`
-				ParagraphCaption  *string `xml:"ParagraphCaption"`
-				ParagraphNum      string  `xml:"ParagraphNum"`
-				ParagraphSentence struct {
-					Sentence []struct {
-						Function    *string `xml:"Function,attr"`
-						Num         string  `xml:"Num,attr"`
-						WritingMode string  `xml:"WritingMode,attr"`
-						CharData    string  `xml:",chardata"`
-						Ruby        []struct {
-							CharData string `xml:",chardata"`
-							Rt       string `xml:"Rt"`
-						} `xml:"Ruby"`
-					} `xml:"Sentence"`
-				} `xml:"ParagraphSentence"`
-			} `xml:"Paragraph"`
-			SupplProvisionLabel string `xml:"SupplProvisionLabel"`
-		} `xml:"SupplProvision"`
-		TOC struct {
-			TOCChapter []struct {
-				Num          string  `xml:"Num,attr"`
-				ArticleRange *string `xml:"ArticleRange"`
-				ChapterTitle string  `xml:"ChapterTitle"`
-				TOCSection   []struct {
-					Num           string  `xml:"Num,attr"`
-					ArticleRange  *string `xml:"ArticleRange"`
-					SectionTitle  string  `xml:"SectionTitle"`
-					TOCSubsection []struct {
-						Num             string `xml:"Num,attr"`
-						ArticleRange    string `xml:"ArticleRange"`
-						SubsectionTitle string `xml:"SubsectionTitle"`
-					} `xml:"TOCSubsection"`
-				} `xml:"TOCSection"`
-			} `xml:"TOCChapter"`
-			TOCLabel          string `xml:"TOCLabel"`
-			TOCSupplProvision struct {
-				SupplProvisionLabel string `xml:"SupplProvisionLabel"`
-			} `xml:"TOCSupplProvision"`
-		} `xml:"TOC"`
-	} `xml:"LawBody"`
-	LawNum string `xml:"LawNum"`
+	LawNum          string   `xml:"LawNum"`
+	LawBody         LawBody  `xml:"LawBody"`
 }
+
+// LawBody represents the body of a law document
+type LawBody struct {
+	Subject         string            `xml:"Subject,attr,omitempty"`
+	LawTitle        *LawTitle         `xml:"LawTitle,omitempty"`
+	EnactStatement  []EnactStatement  `xml:"EnactStatement,omitempty"`
+	TOC             *TOC              `xml:"TOC,omitempty"`
+	Preamble        *Preamble         `xml:"Preamble,omitempty"`
+	MainProvision   MainProvision     `xml:"MainProvision"`
+	SupplProvision  []SupplProvision  `xml:"SupplProvision,omitempty"`
+	AppdxTable      []AppdxTable      `xml:"AppdxTable,omitempty"`
+	AppdxNote       []AppdxNote       `xml:"AppdxNote,omitempty"`
+	AppdxStyle      []AppdxStyle      `xml:"AppdxStyle,omitempty"`
+	Appdx           []Appdx           `xml:"Appdx,omitempty"`
+	AppdxFig        []AppdxFig        `xml:"AppdxFig,omitempty"`
+	AppdxFormat     []AppdxFormat     `xml:"AppdxFormat,omitempty"`
+}
+
+// LawTitle represents the title of a law
+type LawTitle struct {
+	Kana       string  `xml:"Kana,attr,omitempty"`
+	Abbrev     string  `xml:"Abbrev,attr,omitempty"`
+	AbbrevKana string  `xml:"AbbrevKana,attr,omitempty"`
+	Content    string  `xml:",chardata"`
+	Line       []Line  `xml:"Line,omitempty"`
+	Ruby       []Ruby  `xml:"Ruby,omitempty"`
+	Sup        []Sup   `xml:"Sup,omitempty"`
+	Sub        []Sub   `xml:"Sub,omitempty"`
+}
+
+// EnactStatement represents an enactment statement
+type EnactStatement struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// TOC represents the table of contents
+type TOC struct {
+	TOCLabel           *TOCLabel           `xml:"TOCLabel,omitempty"`
+	TOCPreambleLabel   *TOCPreambleLabel   `xml:"TOCPreambleLabel,omitempty"`
+	TOCPart            []TOCPart           `xml:"TOCPart,omitempty"`
+	TOCChapter         []TOCChapter        `xml:"TOCChapter,omitempty"`
+	TOCSection         []TOCSection        `xml:"TOCSection,omitempty"`
+	TOCArticle         []TOCArticle        `xml:"TOCArticle,omitempty"`
+	TOCSupplProvision  *TOCSupplProvision  `xml:"TOCSupplProvision,omitempty"`
+	TOCAppdxTableLabel []TOCAppdxTableLabel `xml:"TOCAppdxTableLabel,omitempty"`
+}
+
+// TOCLabel represents a TOC label
+type TOCLabel struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// TOCPreambleLabel represents a TOC preamble label
+type TOCPreambleLabel struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// TOCPart represents a part in the table of contents
+type TOCPart struct {
+	Num          string        `xml:"Num,attr"`
+	Delete       bool          `xml:"Delete,attr,omitempty"`
+	PartTitle    PartTitle     `xml:"PartTitle"`
+	ArticleRange *ArticleRange `xml:"ArticleRange,omitempty"`
+	TOCChapter   []TOCChapter  `xml:"TOCChapter,omitempty"`
+}
+
+// TOCChapter represents a chapter in the table of contents
+type TOCChapter struct {
+	Num          string        `xml:"Num,attr"`
+	Delete       bool          `xml:"Delete,attr,omitempty"`
+	ChapterTitle ChapterTitle  `xml:"ChapterTitle"`
+	ArticleRange *ArticleRange `xml:"ArticleRange,omitempty"`
+	TOCSection   []TOCSection  `xml:"TOCSection,omitempty"`
+}
+
+// TOCSection represents a section in the table of contents
+type TOCSection struct {
+	Num          string          `xml:"Num,attr"`
+	Delete       bool            `xml:"Delete,attr,omitempty"`
+	SectionTitle SectionTitle    `xml:"SectionTitle"`
+	ArticleRange *ArticleRange   `xml:"ArticleRange,omitempty"`
+	TOCSubsection []TOCSubsection `xml:"TOCSubsection,omitempty"`
+	TOCDivision  []TOCDivision   `xml:"TOCDivision,omitempty"`
+}
+
+// TOCSubsection represents a subsection in the table of contents
+type TOCSubsection struct {
+	Num             string          `xml:"Num,attr"`
+	Delete          bool            `xml:"Delete,attr,omitempty"`
+	SubsectionTitle SubsectionTitle `xml:"SubsectionTitle"`
+	ArticleRange    *ArticleRange   `xml:"ArticleRange,omitempty"`
+	TOCDivision     []TOCDivision   `xml:"TOCDivision,omitempty"`
+}
+
+// TOCDivision represents a division in the table of contents
+type TOCDivision struct {
+	Num          string        `xml:"Num,attr"`
+	Delete       bool          `xml:"Delete,attr,omitempty"`
+	DivisionTitle DivisionTitle `xml:"DivisionTitle"`
+	ArticleRange *ArticleRange `xml:"ArticleRange,omitempty"`
+}
+
+// TOCArticle represents an article in the table of contents
+type TOCArticle struct {
+	Num            string         `xml:"Num,attr"`
+	Delete         bool           `xml:"Delete,attr,omitempty"`
+	ArticleTitle   ArticleTitle   `xml:"ArticleTitle"`
+	ArticleCaption ArticleCaption `xml:"ArticleCaption"`
+}
+
+// TOCSupplProvision represents supplementary provisions in TOC
+type TOCSupplProvision struct {
+	SupplProvisionLabel SupplProvisionLabel `xml:"SupplProvisionLabel"`
+	ArticleRange        *ArticleRange       `xml:"ArticleRange,omitempty"`
+	TOCArticle          []TOCArticle        `xml:"TOCArticle,omitempty"`
+	TOCChapter          []TOCChapter        `xml:"TOCChapter,omitempty"`
+}
+
+// TOCAppdxTableLabel represents an appendix table label in TOC
+type TOCAppdxTableLabel struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// ArticleRange represents an article range
+type ArticleRange struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Preamble represents the preamble section
+type Preamble struct {
+	Paragraph []Paragraph `xml:"Paragraph"`
+}
+
+// MainProvision represents the main provision
+type MainProvision struct {
+	Extract   bool        `xml:"Extract,attr,omitempty"`
+	Part      []Part      `xml:"Part,omitempty"`
+	Chapter   []Chapter   `xml:"Chapter,omitempty"`
+	Section   []Section   `xml:"Section,omitempty"`
+	Article   []Article   `xml:"Article,omitempty"`
+	Paragraph []Paragraph `xml:"Paragraph,omitempty"`
+}
+
+// Part represents a part in the law structure
+type Part struct {
+	Num      string    `xml:"Num,attr"`
+	Delete   bool      `xml:"Delete,attr,omitempty"`
+	Hide     bool      `xml:"Hide,attr,omitempty"`
+	PartTitle PartTitle `xml:"PartTitle"`
+	Article  []Article `xml:"Article,omitempty"`
+	Chapter  []Chapter `xml:"Chapter,omitempty"`
+}
+
+// PartTitle represents a part title
+type PartTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Chapter represents a chapter
+type Chapter struct {
+	Num          string       `xml:"Num,attr"`
+	Delete       bool         `xml:"Delete,attr,omitempty"`
+	Hide         bool         `xml:"Hide,attr,omitempty"`
+	ChapterTitle ChapterTitle `xml:"ChapterTitle"`
+	Article      []Article    `xml:"Article,omitempty"`
+	Section      []Section    `xml:"Section,omitempty"`
+}
+
+// ChapterTitle represents a chapter title
+type ChapterTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Section represents a section
+type Section struct {
+	Num          string       `xml:"Num,attr"`
+	Delete       bool         `xml:"Delete,attr,omitempty"`
+	Hide         bool         `xml:"Hide,attr,omitempty"`
+	SectionTitle SectionTitle `xml:"SectionTitle"`
+	Article      []Article    `xml:"Article,omitempty"`
+	Subsection   []Subsection `xml:"Subsection,omitempty"`
+	Division     []Division   `xml:"Division,omitempty"`
+}
+
+// SectionTitle represents a section title
+type SectionTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Subsection represents a subsection
+type Subsection struct {
+	Num             string          `xml:"Num,attr"`
+	Delete          bool            `xml:"Delete,attr,omitempty"`
+	Hide            bool            `xml:"Hide,attr,omitempty"`
+	SubsectionTitle SubsectionTitle `xml:"SubsectionTitle"`
+	Article         []Article       `xml:"Article,omitempty"`
+	Division        []Division      `xml:"Division,omitempty"`
+}
+
+// SubsectionTitle represents a subsection title
+type SubsectionTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Division represents a division
+type Division struct {
+	Num           string        `xml:"Num,attr"`
+	Delete        bool          `xml:"Delete,attr,omitempty"`
+	Hide          bool          `xml:"Hide,attr,omitempty"`
+	DivisionTitle DivisionTitle `xml:"DivisionTitle"`
+	Article       []Article     `xml:"Article"`
+}
+
+// DivisionTitle represents a division title
+type DivisionTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Article represents an article
+type Article struct {
+	Num            string          `xml:"Num,attr"`
+	Delete         bool            `xml:"Delete,attr,omitempty"`
+	Hide           bool            `xml:"Hide,attr,omitempty"`
+	ArticleCaption *ArticleCaption `xml:"ArticleCaption,omitempty"`
+	ArticleTitle   *ArticleTitle   `xml:"ArticleTitle,omitempty"`
+	Paragraph      []Paragraph     `xml:"Paragraph"`
+	SupplNote      *SupplNote      `xml:"SupplNote,omitempty"`
+}
+
+// ArticleTitle represents an article title
+type ArticleTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// ArticleCaption represents an article caption
+type ArticleCaption struct {
+	CommonCaption bool   `xml:"CommonCaption,attr,omitempty"`
+	Content       string `xml:",chardata"`
+	Line          []Line `xml:"Line,omitempty"`
+	Ruby          []Ruby `xml:"Ruby,omitempty"`
+	Sup           []Sup  `xml:"Sup,omitempty"`
+	Sub           []Sub  `xml:"Sub,omitempty"`
+}
+
+// Paragraph represents a paragraph
+type Paragraph struct {
+	Num               int                `xml:"Num,attr"`
+	OldStyle          bool               `xml:"OldStyle,attr,omitempty"`
+	OldNum            bool               `xml:"OldNum,attr,omitempty"`
+	Hide              bool               `xml:"Hide,attr,omitempty"`
+	ParagraphCaption  *ParagraphCaption  `xml:"ParagraphCaption,omitempty"`
+	ParagraphNum      ParagraphNum       `xml:"ParagraphNum"`
+	ParagraphSentence ParagraphSentence  `xml:"ParagraphSentence"`
+	AmendProvision    []AmendProvision   `xml:"AmendProvision,omitempty"`
+	Class             []Class            `xml:"Class,omitempty"`
+	TableStruct       []TableStruct      `xml:"TableStruct,omitempty"`
+	FigStruct         []FigStruct        `xml:"FigStruct,omitempty"`
+	StyleStruct       []StyleStruct      `xml:"StyleStruct,omitempty"`
+	Item              []Item             `xml:"Item,omitempty"`
+	List              []List             `xml:"List,omitempty"`
+}
+
+// ParagraphCaption represents a paragraph caption
+type ParagraphCaption struct {
+	CommonCaption bool   `xml:"CommonCaption,attr,omitempty"`
+	Content       string `xml:",chardata"`
+	Line          []Line `xml:"Line,omitempty"`
+	Ruby          []Ruby `xml:"Ruby,omitempty"`
+	Sup           []Sup  `xml:"Sup,omitempty"`
+	Sub           []Sub  `xml:"Sub,omitempty"`
+}
+
+// ParagraphNum represents a paragraph number
+type ParagraphNum struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// ParagraphSentence represents paragraph sentences
+type ParagraphSentence struct {
+	Sentence []Sentence `xml:"Sentence"`
+}
+
+// SupplNote represents a supplementary note
+type SupplNote struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// AmendProvision represents an amendment provision
+type AmendProvision struct {
+	AmendProvisionSentence *AmendProvisionSentence `xml:"AmendProvisionSentence,omitempty"`
+	NewProvision           []NewProvision          `xml:"NewProvision,omitempty"`
+}
+
+// AmendProvisionSentence represents an amendment provision sentence
+type AmendProvisionSentence struct {
+	Sentence Sentence `xml:"Sentence"`
+}
+
+// NewProvision represents a new provision
+type NewProvision struct {
+	Content                   string                      `xml:",innerxml"`
+	LawTitle                  *LawTitle                   `xml:"LawTitle,omitempty"`
+	Preamble                  *Preamble                   `xml:"Preamble,omitempty"`
+	TOC                       *TOC                        `xml:"TOC,omitempty"`
+	Part                      []Part                      `xml:"Part,omitempty"`
+	PartTitle                 []PartTitle                 `xml:"PartTitle,omitempty"`
+	Chapter                   []Chapter                   `xml:"Chapter,omitempty"`
+	ChapterTitle              []ChapterTitle              `xml:"ChapterTitle,omitempty"`
+	Section                   []Section                   `xml:"Section,omitempty"`
+	SectionTitle              []SectionTitle              `xml:"SectionTitle,omitempty"`
+	Subsection                []Subsection                `xml:"Subsection,omitempty"`
+	SubsectionTitle           []SubsectionTitle           `xml:"SubsectionTitle,omitempty"`
+	Division                  []Division                  `xml:"Division,omitempty"`
+	DivisionTitle             []DivisionTitle             `xml:"DivisionTitle,omitempty"`
+	Article                   []Article                   `xml:"Article,omitempty"`
+	SupplNote                 []SupplNote                 `xml:"SupplNote,omitempty"`
+	Paragraph                 []Paragraph                 `xml:"Paragraph,omitempty"`
+	Item                      []Item                      `xml:"Item,omitempty"`
+	Subitem1                  []Subitem1                  `xml:"Subitem1,omitempty"`
+	Subitem2                  []Subitem2                  `xml:"Subitem2,omitempty"`
+	Subitem3                  []Subitem3                  `xml:"Subitem3,omitempty"`
+	Subitem4                  []Subitem4                  `xml:"Subitem4,omitempty"`
+	Subitem5                  []Subitem5                  `xml:"Subitem5,omitempty"`
+	Subitem6                  []Subitem6                  `xml:"Subitem6,omitempty"`
+	Subitem7                  []Subitem7                  `xml:"Subitem7,omitempty"`
+	Subitem8                  []Subitem8                  `xml:"Subitem8,omitempty"`
+	Subitem9                  []Subitem9                  `xml:"Subitem9,omitempty"`
+	Subitem10                 []Subitem10                 `xml:"Subitem10,omitempty"`
+	List                      []List                      `xml:"List,omitempty"`
+	Sentence                  []Sentence                  `xml:"Sentence,omitempty"`
+	AmendProvision            []AmendProvision            `xml:"AmendProvision,omitempty"`
+	AppdxTable                []AppdxTable                `xml:"AppdxTable,omitempty"`
+	AppdxNote                 []AppdxNote                 `xml:"AppdxNote,omitempty"`
+	AppdxStyle                []AppdxStyle                `xml:"AppdxStyle,omitempty"`
+	Appdx                     []Appdx                     `xml:"Appdx,omitempty"`
+	AppdxFig                  []AppdxFig                  `xml:"AppdxFig,omitempty"`
+	AppdxFormat               []AppdxFormat               `xml:"AppdxFormat,omitempty"`
+	SupplProvisionAppdxStyle  []SupplProvisionAppdxStyle  `xml:"SupplProvisionAppdxStyle,omitempty"`
+	SupplProvisionAppdxTable  []SupplProvisionAppdxTable  `xml:"SupplProvisionAppdxTable,omitempty"`
+	SupplProvisionAppdx       []SupplProvisionAppdx       `xml:"SupplProvisionAppdx,omitempty"`
+	TableStruct               *TableStruct                `xml:"TableStruct,omitempty"`
+	TableRow                  []TableRow                  `xml:"TableRow,omitempty"`
+	TableColumn               []TableColumn               `xml:"TableColumn,omitempty"`
+	FigStruct                 *FigStruct                  `xml:"FigStruct,omitempty"`
+	NoteStruct                *NoteStruct                 `xml:"NoteStruct,omitempty"`
+	StyleStruct               *StyleStruct                `xml:"StyleStruct,omitempty"`
+	FormatStruct              *FormatStruct               `xml:"FormatStruct,omitempty"`
+	Remarks                   *Remarks                    `xml:"Remarks,omitempty"`
+	LawBody                   *LawBody                    `xml:"LawBody,omitempty"`
+}
+
+// Class represents a class
+type Class struct {
+	Num           string         `xml:"Num,attr"`
+	ClassTitle    *ClassTitle    `xml:"ClassTitle,omitempty"`
+	ClassSentence ClassSentence  `xml:"ClassSentence"`
+	Item          []Item         `xml:"Item,omitempty"`
+}
+
+// ClassTitle represents a class title
+type ClassTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// ClassSentence represents a class sentence
+type ClassSentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+// Item represents an item
+type Item struct {
+	Num          string        `xml:"Num,attr"`
+	Delete       bool          `xml:"Delete,attr,omitempty"`
+	Hide         bool          `xml:"Hide,attr,omitempty"`
+	ItemTitle    *ItemTitle    `xml:"ItemTitle,omitempty"`
+	ItemSentence ItemSentence  `xml:"ItemSentence"`
+	Subitem1     []Subitem1    `xml:"Subitem1,omitempty"`
+	TableStruct  []TableStruct `xml:"TableStruct,omitempty"`
+	FigStruct    []FigStruct   `xml:"FigStruct,omitempty"`
+	StyleStruct  []StyleStruct `xml:"StyleStruct,omitempty"`
+	List         []List        `xml:"List,omitempty"`
+}
+
+// ItemTitle represents an item title
+type ItemTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// ItemSentence represents an item sentence
+type ItemSentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+// Subitem1 through Subitem10 represent nested subitems
+type Subitem1 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem1Title    *Subitem1Title    `xml:"Subitem1Title,omitempty"`
+	Subitem1Sentence Subitem1Sentence  `xml:"Subitem1Sentence"`
+	Subitem2         []Subitem2        `xml:"Subitem2,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem1Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem1Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem2 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem2Title    *Subitem2Title    `xml:"Subitem2Title,omitempty"`
+	Subitem2Sentence Subitem2Sentence  `xml:"Subitem2Sentence"`
+	Subitem3         []Subitem3        `xml:"Subitem3,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem2Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem2Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem3 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem3Title    *Subitem3Title    `xml:"Subitem3Title,omitempty"`
+	Subitem3Sentence Subitem3Sentence  `xml:"Subitem3Sentence"`
+	Subitem4         []Subitem4        `xml:"Subitem4,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem3Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem3Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem4 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem4Title    *Subitem4Title    `xml:"Subitem4Title,omitempty"`
+	Subitem4Sentence Subitem4Sentence  `xml:"Subitem4Sentence"`
+	Subitem5         []Subitem5        `xml:"Subitem5,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem4Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem4Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem5 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem5Title    *Subitem5Title    `xml:"Subitem5Title,omitempty"`
+	Subitem5Sentence Subitem5Sentence  `xml:"Subitem5Sentence"`
+	Subitem6         []Subitem6        `xml:"Subitem6,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem5Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem5Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem6 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem6Title    *Subitem6Title    `xml:"Subitem6Title,omitempty"`
+	Subitem6Sentence Subitem6Sentence  `xml:"Subitem6Sentence"`
+	Subitem7         []Subitem7        `xml:"Subitem7,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem6Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem6Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem7 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem7Title    *Subitem7Title    `xml:"Subitem7Title,omitempty"`
+	Subitem7Sentence Subitem7Sentence  `xml:"Subitem7Sentence"`
+	Subitem8         []Subitem8        `xml:"Subitem8,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem7Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem7Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem8 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem8Title    *Subitem8Title    `xml:"Subitem8Title,omitempty"`
+	Subitem8Sentence Subitem8Sentence  `xml:"Subitem8Sentence"`
+	Subitem9         []Subitem9        `xml:"Subitem9,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem8Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem8Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem9 struct {
+	Num              string            `xml:"Num,attr"`
+	Delete           bool              `xml:"Delete,attr,omitempty"`
+	Hide             bool              `xml:"Hide,attr,omitempty"`
+	Subitem9Title    *Subitem9Title    `xml:"Subitem9Title,omitempty"`
+	Subitem9Sentence Subitem9Sentence  `xml:"Subitem9Sentence"`
+	Subitem10        []Subitem10       `xml:"Subitem10,omitempty"`
+	TableStruct      []TableStruct     `xml:"TableStruct,omitempty"`
+	FigStruct        []FigStruct       `xml:"FigStruct,omitempty"`
+	StyleStruct      []StyleStruct     `xml:"StyleStruct,omitempty"`
+	List             []List            `xml:"List,omitempty"`
+}
+
+type Subitem9Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem9Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+type Subitem10 struct {
+	Num               string             `xml:"Num,attr"`
+	Delete            bool               `xml:"Delete,attr,omitempty"`
+	Hide              bool               `xml:"Hide,attr,omitempty"`
+	Subitem10Title    *Subitem10Title    `xml:"Subitem10Title,omitempty"`
+	Subitem10Sentence Subitem10Sentence  `xml:"Subitem10Sentence"`
+	TableStruct       []TableStruct      `xml:"TableStruct,omitempty"`
+	FigStruct         []FigStruct        `xml:"FigStruct,omitempty"`
+	StyleStruct       []StyleStruct      `xml:"StyleStruct,omitempty"`
+	List              []List             `xml:"List,omitempty"`
+}
+
+type Subitem10Title struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+type Subitem10Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+	Table    *Table     `xml:"Table,omitempty"`
+}
+
+// Sentence represents a sentence
+type Sentence struct {
+	Num         int          `xml:"Num,attr,omitempty"`
+	Function    string       `xml:"Function,attr,omitempty"` // main or proviso
+	Indent      string       `xml:"Indent,attr,omitempty"`
+	WritingMode WritingMode  `xml:"WritingMode,attr,omitempty"`
+	Content     string       `xml:",chardata"`
+	Line        []Line       `xml:"Line,omitempty"`
+	QuoteStruct []QuoteStruct `xml:"QuoteStruct,omitempty"`
+	ArithFormula []ArithFormula `xml:"ArithFormula,omitempty"`
+	Ruby        []Ruby       `xml:"Ruby,omitempty"`
+	Sup         []Sup        `xml:"Sup,omitempty"`
+	Sub         []Sub        `xml:"Sub,omitempty"`
+}
+
+// Column represents a column
+type Column struct {
+	Num        int       `xml:"Num,attr,omitempty"`
+	LineBreak  bool      `xml:"LineBreak,attr,omitempty"`
+	Align      string    `xml:"Align,attr,omitempty"` // left, center, right, justify
+	Sentence   []Sentence `xml:"Sentence"`
+}
+
+// SupplProvision represents supplementary provisions
+type SupplProvision struct {
+	Type                     string                      `xml:"Type,attr,omitempty"` // New or Amend
+	AmendLawNum              string                      `xml:"AmendLawNum,attr,omitempty"`
+	Extract                  bool                        `xml:"Extract,attr,omitempty"`
+	SupplProvisionLabel      SupplProvisionLabel         `xml:"SupplProvisionLabel"`
+	Chapter                  []Chapter                   `xml:"Chapter,omitempty"`
+	Article                  []Article                   `xml:"Article,omitempty"`
+	Paragraph                []Paragraph                 `xml:"Paragraph,omitempty"`
+	SupplProvisionAppdxTable []SupplProvisionAppdxTable  `xml:"SupplProvisionAppdxTable,omitempty"`
+	SupplProvisionAppdxStyle []SupplProvisionAppdxStyle  `xml:"SupplProvisionAppdxStyle,omitempty"`
+	SupplProvisionAppdx      []SupplProvisionAppdx       `xml:"SupplProvisionAppdx,omitempty"`
+}
+
+// SupplProvisionLabel represents a supplementary provision label
+type SupplProvisionLabel struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// SupplProvisionAppdxTable represents supplementary provision appendix table
+type SupplProvisionAppdxTable struct {
+	Num                          int                           `xml:"Num,attr,omitempty"`
+	SupplProvisionAppdxTableTitle SupplProvisionAppdxTableTitle `xml:"SupplProvisionAppdxTableTitle"`
+	RelatedArticleNum            *RelatedArticleNum            `xml:"RelatedArticleNum,omitempty"`
+	TableStruct                  []TableStruct                 `xml:"TableStruct,omitempty"`
+}
+
+// SupplProvisionAppdxTableTitle represents title for supplementary provision appendix table
+type SupplProvisionAppdxTableTitle struct {
+	WritingMode WritingMode `xml:"WritingMode,attr,omitempty"`
+	Content     string      `xml:",chardata"`
+	Line        []Line      `xml:"Line,omitempty"`
+	Ruby        []Ruby      `xml:"Ruby,omitempty"`
+	Sup         []Sup       `xml:"Sup,omitempty"`
+	Sub         []Sub       `xml:"Sub,omitempty"`
+}
+
+// SupplProvisionAppdxStyle represents supplementary provision appendix style
+type SupplProvisionAppdxStyle struct {
+	Num                          int                           `xml:"Num,attr,omitempty"`
+	SupplProvisionAppdxStyleTitle SupplProvisionAppdxStyleTitle `xml:"SupplProvisionAppdxStyleTitle"`
+	RelatedArticleNum            *RelatedArticleNum            `xml:"RelatedArticleNum,omitempty"`
+	StyleStruct                  []StyleStruct                 `xml:"StyleStruct,omitempty"`
+}
+
+// SupplProvisionAppdxStyleTitle represents title for supplementary provision appendix style
+type SupplProvisionAppdxStyleTitle struct {
+	WritingMode WritingMode `xml:"WritingMode,attr,omitempty"`
+	Content     string      `xml:",chardata"`
+	Line        []Line      `xml:"Line,omitempty"`
+	Ruby        []Ruby      `xml:"Ruby,omitempty"`
+	Sup         []Sup       `xml:"Sup,omitempty"`
+	Sub         []Sub       `xml:"Sub,omitempty"`
+}
+
+// SupplProvisionAppdx represents supplementary provision appendix
+type SupplProvisionAppdx struct {
+	Num               int                `xml:"Num,attr,omitempty"`
+	ArithFormulaNum   *ArithFormulaNum   `xml:"ArithFormulaNum,omitempty"`
+	RelatedArticleNum *RelatedArticleNum `xml:"RelatedArticleNum,omitempty"`
+	ArithFormula      []ArithFormula     `xml:"ArithFormula"`
+}
+
+// AppdxTable represents an appendix table
+type AppdxTable struct {
+	Num               int                `xml:"Num,attr,omitempty"`
+	AppdxTableTitle   *AppdxTableTitle   `xml:"AppdxTableTitle,omitempty"`
+	RelatedArticleNum *RelatedArticleNum `xml:"RelatedArticleNum,omitempty"`
+	TableStruct       []TableStruct      `xml:"TableStruct,omitempty"`
+	Item              []Item             `xml:"Item,omitempty"`
+	Remarks           *Remarks           `xml:"Remarks,omitempty"`
+}
+
+// AppdxTableTitle represents an appendix table title
+type AppdxTableTitle struct {
+	WritingMode WritingMode `xml:"WritingMode,attr,omitempty"`
+	Content     string      `xml:",chardata"`
+	Line        []Line      `xml:"Line,omitempty"`
+	Ruby        []Ruby      `xml:"Ruby,omitempty"`
+	Sup         []Sup       `xml:"Sup,omitempty"`
+	Sub         []Sub       `xml:"Sub,omitempty"`
+}
+
+// AppdxNote represents an appendix note
+type AppdxNote struct {
+	Num               int                `xml:"Num,attr,omitempty"`
+	AppdxNoteTitle    *AppdxNoteTitle    `xml:"AppdxNoteTitle,omitempty"`
+	RelatedArticleNum *RelatedArticleNum `xml:"RelatedArticleNum,omitempty"`
+	NoteStruct        []NoteStruct       `xml:"NoteStruct,omitempty"`
+	FigStruct         []FigStruct        `xml:"FigStruct,omitempty"`
+	TableStruct       []TableStruct      `xml:"TableStruct,omitempty"`
+	Remarks           *Remarks           `xml:"Remarks,omitempty"`
+}
+
+// AppdxNoteTitle represents an appendix note title
+type AppdxNoteTitle struct {
+	WritingMode WritingMode `xml:"WritingMode,attr,omitempty"`
+	Content     string      `xml:",chardata"`
+	Line        []Line      `xml:"Line,omitempty"`
+	Ruby        []Ruby      `xml:"Ruby,omitempty"`
+	Sup         []Sup       `xml:"Sup,omitempty"`
+	Sub         []Sub       `xml:"Sub,omitempty"`
+}
+
+// AppdxStyle represents an appendix style
+type AppdxStyle struct {
+	Num               int                `xml:"Num,attr,omitempty"`
+	AppdxStyleTitle   *AppdxStyleTitle   `xml:"AppdxStyleTitle,omitempty"`
+	RelatedArticleNum *RelatedArticleNum `xml:"RelatedArticleNum,omitempty"`
+	StyleStruct       []StyleStruct      `xml:"StyleStruct,omitempty"`
+	Remarks           *Remarks           `xml:"Remarks,omitempty"`
+}
+
+// AppdxStyleTitle represents an appendix style title
+type AppdxStyleTitle struct {
+	WritingMode WritingMode `xml:"WritingMode,attr,omitempty"`
+	Content     string      `xml:",chardata"`
+	Line        []Line      `xml:"Line,omitempty"`
+	Ruby        []Ruby      `xml:"Ruby,omitempty"`
+	Sup         []Sup       `xml:"Sup,omitempty"`
+	Sub         []Sub       `xml:"Sub,omitempty"`
+}
+
+// AppdxFormat represents an appendix format
+type AppdxFormat struct {
+	Num               int                `xml:"Num,attr,omitempty"`
+	AppdxFormatTitle  *AppdxFormatTitle  `xml:"AppdxFormatTitle,omitempty"`
+	RelatedArticleNum *RelatedArticleNum `xml:"RelatedArticleNum,omitempty"`
+	FormatStruct      []FormatStruct     `xml:"FormatStruct,omitempty"`
+	Remarks           *Remarks           `xml:"Remarks,omitempty"`
+}
+
+// AppdxFormatTitle represents an appendix format title
+type AppdxFormatTitle struct {
+	WritingMode WritingMode `xml:"WritingMode,attr,omitempty"`
+	Content     string      `xml:",chardata"`
+	Line        []Line      `xml:"Line,omitempty"`
+	Ruby        []Ruby      `xml:"Ruby,omitempty"`
+	Sup         []Sup       `xml:"Sup,omitempty"`
+	Sub         []Sub       `xml:"Sub,omitempty"`
+}
+
+// Appdx represents an appendix
+type Appdx struct {
+	ArithFormulaNum   *ArithFormulaNum   `xml:"ArithFormulaNum,omitempty"`
+	RelatedArticleNum *RelatedArticleNum `xml:"RelatedArticleNum,omitempty"`
+	ArithFormula      []ArithFormula     `xml:"ArithFormula"`
+	Remarks           *Remarks           `xml:"Remarks,omitempty"`
+}
+
+// ArithFormulaNum represents an arithmetic formula number
+type ArithFormulaNum struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// ArithFormula represents an arithmetic formula
+type ArithFormula struct {
+	Num     int    `xml:"Num,attr,omitempty"`
+	Content string `xml:",innerxml"`
+}
+
+// AppdxFig represents an appendix figure
+type AppdxFig struct {
+	Num               int                `xml:"Num,attr,omitempty"`
+	AppdxFigTitle     *AppdxFigTitle     `xml:"AppdxFigTitle,omitempty"`
+	RelatedArticleNum *RelatedArticleNum `xml:"RelatedArticleNum,omitempty"`
+	FigStruct         []FigStruct        `xml:"FigStruct,omitempty"`
+	TableStruct       []TableStruct      `xml:"TableStruct,omitempty"`
+}
+
+// AppdxFigTitle represents an appendix figure title
+type AppdxFigTitle struct {
+	WritingMode WritingMode `xml:"WritingMode,attr,omitempty"`
+	Content     string      `xml:",chardata"`
+	Line        []Line      `xml:"Line,omitempty"`
+	Ruby        []Ruby      `xml:"Ruby,omitempty"`
+	Sup         []Sup       `xml:"Sup,omitempty"`
+	Sub         []Sub       `xml:"Sub,omitempty"`
+}
+
+// TableStruct represents a table structure
+type TableStruct struct {
+	TableStructTitle *TableStructTitle `xml:"TableStructTitle,omitempty"`
+	Table            Table             `xml:"Table"`
+	Remarks          []Remarks         `xml:"Remarks,omitempty"`
+}
+
+// TableStructTitle represents a table structure title
+type TableStructTitle struct {
+	WritingMode WritingMode `xml:"WritingMode,attr,omitempty"`
+	Content     string      `xml:",chardata"`
+	Line        []Line      `xml:"Line,omitempty"`
+	Ruby        []Ruby      `xml:"Ruby,omitempty"`
+	Sup         []Sup       `xml:"Sup,omitempty"`
+	Sub         []Sub       `xml:"Sub,omitempty"`
+}
+
+// Table represents a table
+type Table struct {
+	WritingMode     WritingMode       `xml:"WritingMode,attr,omitempty"`
+	TableHeaderRow  []TableHeaderRow  `xml:"TableHeaderRow,omitempty"`
+	TableRow        []TableRow        `xml:"TableRow"`
+}
+
+// TableRow represents a table row
+type TableRow struct {
+	TableColumn []TableColumn `xml:"TableColumn"`
+}
+
+// TableHeaderRow represents a table header row
+type TableHeaderRow struct {
+	TableHeaderColumn []TableHeaderColumn `xml:"TableHeaderColumn"`
+}
+
+// TableHeaderColumn represents a table header column
+type TableHeaderColumn struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// TableColumn represents a table column
+type TableColumn struct {
+	BorderTop    string       `xml:"BorderTop,attr,omitempty"`    // solid, none, dotted, double
+	BorderBottom string       `xml:"BorderBottom,attr,omitempty"` // solid, none, dotted, double
+	BorderLeft   string       `xml:"BorderLeft,attr,omitempty"`   // solid, none, dotted, double
+	BorderRight  string       `xml:"BorderRight,attr,omitempty"`  // solid, none, dotted, double
+	Rowspan      string       `xml:"rowspan,attr,omitempty"`
+	Colspan      string       `xml:"colspan,attr,omitempty"`
+	Align        string       `xml:"Align,attr,omitempty"`        // left, center, right, justify
+	Valign       string       `xml:"Valign,attr,omitempty"`       // top, middle, bottom
+	Part         []Part       `xml:"Part,omitempty"`
+	Chapter      []Chapter    `xml:"Chapter,omitempty"`
+	Section      []Section    `xml:"Section,omitempty"`
+	Subsection   []Subsection `xml:"Subsection,omitempty"`
+	Division     []Division   `xml:"Division,omitempty"`
+	Article      []Article    `xml:"Article,omitempty"`
+	Paragraph    []Paragraph  `xml:"Paragraph,omitempty"`
+	Item         []Item       `xml:"Item,omitempty"`
+	Subitem1     []Subitem1   `xml:"Subitem1,omitempty"`
+	Subitem2     []Subitem2   `xml:"Subitem2,omitempty"`
+	Subitem3     []Subitem3   `xml:"Subitem3,omitempty"`
+	Subitem4     []Subitem4   `xml:"Subitem4,omitempty"`
+	Subitem5     []Subitem5   `xml:"Subitem5,omitempty"`
+	Subitem6     []Subitem6   `xml:"Subitem6,omitempty"`
+	Subitem7     []Subitem7   `xml:"Subitem7,omitempty"`
+	Subitem8     []Subitem8   `xml:"Subitem8,omitempty"`
+	Subitem9     []Subitem9   `xml:"Subitem9,omitempty"`
+	Subitem10    []Subitem10  `xml:"Subitem10,omitempty"`
+	FigStruct    []FigStruct  `xml:"FigStruct,omitempty"`
+	Remarks      *Remarks     `xml:"Remarks,omitempty"`
+	Sentence     []Sentence   `xml:"Sentence,omitempty"`
+	Column       []Column     `xml:"Column,omitempty"`
+}
+
+// FigStruct represents a figure structure
+type FigStruct struct {
+	FigStructTitle *FigStructTitle `xml:"FigStructTitle,omitempty"`
+	Fig            Fig             `xml:"Fig"`
+	Remarks        []Remarks       `xml:"Remarks,omitempty"`
+}
+
+// FigStructTitle represents a figure structure title
+type FigStructTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Fig represents a figure
+type Fig struct {
+	Src string `xml:"src,attr"`
+}
+
+// NoteStruct represents a note structure
+type NoteStruct struct {
+	NoteStructTitle *NoteStructTitle `xml:"NoteStructTitle,omitempty"`
+	Note            Note             `xml:"Note"`
+	Remarks         []Remarks        `xml:"Remarks,omitempty"`
+}
+
+// NoteStructTitle represents a note structure title
+type NoteStructTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Note represents a note
+type Note struct {
+	Content string `xml:",innerxml"`
+}
+
+// StyleStruct represents a style structure
+type StyleStruct struct {
+	StyleStructTitle *StyleStructTitle `xml:"StyleStructTitle,omitempty"`
+	Style            Style             `xml:"Style"`
+	Remarks          []Remarks         `xml:"Remarks,omitempty"`
+}
+
+// StyleStructTitle represents a style structure title
+type StyleStructTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Style represents a style
+type Style struct {
+	Content string `xml:",innerxml"`
+}
+
+// FormatStruct represents a format structure
+type FormatStruct struct {
+	FormatStructTitle *FormatStructTitle `xml:"FormatStructTitle,omitempty"`
+	Format            Format             `xml:"Format"`
+	Remarks           []Remarks          `xml:"Remarks,omitempty"`
+}
+
+// FormatStructTitle represents a format structure title
+type FormatStructTitle struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Format represents a format
+type Format struct {
+	Content string `xml:",innerxml"`
+}
+
+// RelatedArticleNum represents a related article number
+type RelatedArticleNum struct {
+	Content string `xml:",chardata"`
+	Line    []Line `xml:"Line,omitempty"`
+	Ruby    []Ruby `xml:"Ruby,omitempty"`
+	Sup     []Sup  `xml:"Sup,omitempty"`
+	Sub     []Sub  `xml:"Sub,omitempty"`
+}
+
+// Remarks represents remarks
+type Remarks struct {
+	RemarksLabel RemarksLabel `xml:"RemarksLabel"`
+	Item         []Item       `xml:"Item,omitempty"`
+	Sentence     []Sentence   `xml:"Sentence,omitempty"`
+}
+
+// RemarksLabel represents a remarks label
+type RemarksLabel struct {
+	LineBreak bool   `xml:"LineBreak,attr,omitempty"`
+	Content   string `xml:",chardata"`
+	Line      []Line `xml:"Line,omitempty"`
+	Ruby      []Ruby `xml:"Ruby,omitempty"`
+	Sup       []Sup  `xml:"Sup,omitempty"`
+	Sub       []Sub  `xml:"Sub,omitempty"`
+}
+
+// List represents a list
+type List struct {
+	ListSentence ListSentence `xml:"ListSentence"`
+	Sublist1     []Sublist1   `xml:"Sublist1,omitempty"`
+}
+
+// ListSentence represents a list sentence
+type ListSentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+}
+
+// Sublist1 represents a first-level sublist
+type Sublist1 struct {
+	Sublist1Sentence Sublist1Sentence `xml:"Sublist1Sentence"`
+	Sublist2         []Sublist2       `xml:"Sublist2,omitempty"`
+}
+
+// Sublist1Sentence represents a first-level sublist sentence
+type Sublist1Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+}
+
+// Sublist2 represents a second-level sublist
+type Sublist2 struct {
+	Sublist2Sentence Sublist2Sentence `xml:"Sublist2Sentence"`
+	Sublist3         []Sublist3       `xml:"Sublist3,omitempty"`
+}
+
+// Sublist2Sentence represents a second-level sublist sentence
+type Sublist2Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+}
+
+// Sublist3 represents a third-level sublist
+type Sublist3 struct {
+	Sublist3Sentence Sublist3Sentence `xml:"Sublist3Sentence"`
+}
+
+// Sublist3Sentence represents a third-level sublist sentence
+type Sublist3Sentence struct {
+	Sentence []Sentence `xml:"Sentence,omitempty"`
+	Column   []Column   `xml:"Column,omitempty"`
+}
+
+// QuoteStruct represents a quote structure
+type QuoteStruct struct {
+	Content string `xml:",innerxml"`
+}
+
+// Ruby represents ruby text (phonetic guides)
+type Ruby struct {
+	Content string `xml:",chardata"`
+	Rt      []Rt   `xml:"Rt,omitempty"`
+}
+
+// Rt represents ruby text content
+type Rt struct {
+	Content string `xml:",chardata"`
+}
+
+// Line represents a line
+type Line struct {
+	Style        string         `xml:"Style,attr,omitempty"` // dotted, double, none, solid
+	Content      string         `xml:",chardata"`
+	QuoteStruct  []QuoteStruct  `xml:"QuoteStruct,omitempty"`
+	ArithFormula []ArithFormula `xml:"ArithFormula,omitempty"`
+	Ruby         []Ruby         `xml:"Ruby,omitempty"`
+	Sup          []Sup          `xml:"Sup,omitempty"`
+	Sub          []Sub          `xml:"Sub,omitempty"`
+}
+
+// Sup represents superscript text
+type Sup struct {
+	Content string `xml:",chardata"`
+}
+
+// Sub represents subscript text
+type Sub struct {
+	Content string `xml:",chardata"`
+}
+
+// WritingMode represents text direction
+type WritingMode string
+
+const (
+	WritingModeVertical   WritingMode = "vertical"
+	WritingModeHorizontal WritingMode = "horizontal"
+)

--- a/schema_test.go
+++ b/schema_test.go
@@ -2,105 +2,280 @@ package jplaw
 
 import (
 	"encoding/xml"
-	"io"
 	"os"
 	"testing"
 )
 
-func TestParseSchema(t *testing.T) {
-	file, err := os.Open("fixtures/327AC0000000231_20240401_505AC0000000063.xml")
+func TestUnmarshalLaw(t *testing.T) {
+	// Read the test XML file
+	data, err := os.ReadFile("fixtures/327AC0000000231_20240401_505AC0000000063.xml")
 	if err != nil {
-		t.Fatalf("Failed to open file: %v", err)
+		t.Fatalf("Failed to read test file: %v", err)
 	}
-	defer file.Close()
 
-	data, err := io.ReadAll(file)
+	// Unmarshal into our Law struct
+	var law Law
+	err = xml.Unmarshal(data, &law)
 	if err != nil {
-		t.Fatalf("Failed to read file: %v", err)
+		t.Fatalf("Failed to unmarshal XML: %v", err)
 	}
 
-	var schema Law
-	err = xml.Unmarshal(data, &schema)
+	// Test root Law element attributes
+	if law.Era != EraShowa {
+		t.Errorf("Expected Era to be Showa, got %v", law.Era)
+	}
+	if law.Lang != LanguageJapanese {
+		t.Errorf("Expected Lang to be ja, got %v", law.Lang)
+	}
+	if law.LawType != LawTypeAct {
+		t.Errorf("Expected LawType to be Act, got %v", law.LawType)
+	}
+	if law.Num != "231" {
+		t.Errorf("Expected Num to be 231, got %v", law.Num)
+	}
+	if law.Year != 27 {
+		t.Errorf("Expected Year to be 27, got %v", law.Year)
+	}
+	if law.PromulgateMonth != 7 {
+		t.Errorf("Expected PromulgateMonth to be 7, got %v", law.PromulgateMonth)
+	}
+	if law.PromulgateDay != 15 {
+		t.Errorf("Expected PromulgateDay to be 15, got %v", law.PromulgateDay)
+	}
 
+	// Test LawNum
+	expectedLawNum := "昭和二十七年法律第二百三十一号"
+	if law.LawNum != expectedLawNum {
+		t.Errorf("Expected LawNum to be %s, got %s", expectedLawNum, law.LawNum)
+	}
+
+	// Test LawTitle
+	if law.LawBody.LawTitle == nil {
+		t.Fatal("Expected LawTitle to be non-nil")
+	}
+	expectedTitle := "航空法"
+	if law.LawBody.LawTitle.Content != expectedTitle {
+		t.Errorf("Expected LawTitle content to be %s, got %s", expectedTitle, law.LawBody.LawTitle.Content)
+	}
+	expectedKana := "こうくうほう"
+	if law.LawBody.LawTitle.Kana != expectedKana {
+		t.Errorf("Expected LawTitle Kana to be %s, got %s", expectedKana, law.LawBody.LawTitle.Kana)
+	}
+
+	// Test TOC existence
+	if law.LawBody.TOC == nil {
+		t.Fatal("Expected TOC to be non-nil")
+	}
+	
+	// Test TOCLabel
+	if law.LawBody.TOC.TOCLabel == nil {
+		t.Fatal("Expected TOCLabel to be non-nil")
+	}
+	expectedTOCLabel := "目次"
+	if law.LawBody.TOC.TOCLabel.Content != expectedTOCLabel {
+		t.Errorf("Expected TOCLabel content to be %s, got %s", expectedTOCLabel, law.LawBody.TOC.TOCLabel.Content)
+	}
+
+	// Test TOCChapter count and first chapter
+	if len(law.LawBody.TOC.TOCChapter) == 0 {
+		t.Fatal("Expected at least one TOCChapter")
+	}
+	
+	firstChapter := law.LawBody.TOC.TOCChapter[0]
+	if firstChapter.Num != "1" {
+		t.Errorf("Expected first TOCChapter Num to be 1, got %s", firstChapter.Num)
+	}
+	expectedChapterTitle := "第一章　総則"
+	if firstChapter.ChapterTitle.Content != expectedChapterTitle {
+		t.Errorf("Expected first TOCChapter title to be %s, got %s", expectedChapterTitle, firstChapter.ChapterTitle.Content)
+	}
+	
+	// Test ArticleRange for first chapter
+	if firstChapter.ArticleRange == nil {
+		t.Fatal("Expected first TOCChapter ArticleRange to be non-nil")
+	}
+	expectedArticleRange := "（第一条・第二条）"
+	if firstChapter.ArticleRange.Content != expectedArticleRange {
+		t.Errorf("Expected first TOCChapter ArticleRange to be %s, got %s", expectedArticleRange, firstChapter.ArticleRange.Content)
+	}
+
+	// Test that we have sections in chapter 9
+	chapter9Found := false
+	for _, chapter := range law.LawBody.TOC.TOCChapter {
+		if chapter.Num == "9" {
+			chapter9Found = true
+			if len(chapter.TOCSection) == 0 {
+				t.Error("Expected Chapter 9 to have TOCSections")
+			}
+			if len(chapter.TOCSection) > 0 {
+				firstSection := chapter.TOCSection[0]
+				if firstSection.Num != "1" {
+					t.Errorf("Expected first section in Chapter 9 to have Num 1, got %s", firstSection.Num)
+				}
+				expectedSectionTitle := "第一節　危害行為防止基本方針等"
+				if firstSection.SectionTitle.Content != expectedSectionTitle {
+					t.Errorf("Expected first section title to be %s, got %s", expectedSectionTitle, firstSection.SectionTitle.Content)
+				}
+			}
+			break
+		}
+	}
+	if !chapter9Found {
+		t.Error("Expected to find Chapter 9 in TOC")
+	}
+}
+
+func TestMarshalLaw(t *testing.T) {
+	// Create a simple Law struct for testing marshaling
+	law := Law{
+		Era:             EraHeisei,
+		Year:            31,
+		Num:             "1",
+		PromulgateMonth: 4,
+		PromulgateDay:   1,
+		LawType:         LawTypeAct,
+		Lang:            LanguageJapanese,
+		LawNum:          "平成三十一年法律第一号",
+		LawBody: LawBody{
+			LawTitle: &LawTitle{
+				Content: "テスト法",
+				Kana:    "てすとほう",
+			},
+			MainProvision: MainProvision{
+				Article: []Article{
+					{
+						Num: "1",
+						ArticleTitle: &ArticleTitle{
+							Content: "目的",
+						},
+						Paragraph: []Paragraph{
+							{
+								Num: 1,
+								ParagraphNum: ParagraphNum{
+									Content: "1",
+								},
+								ParagraphSentence: ParagraphSentence{
+									Sentence: []Sentence{
+										{
+											Num:     1,
+											Content: "この法律は、テストを目的とする。",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Marshal to XML
+	data, err := xml.MarshalIndent(law, "", "  ")
 	if err != nil {
-		t.Fatalf("Failed to parse schema: %v", err)
+		t.Fatalf("Failed to marshal Law to XML: %v", err)
 	}
 
-	if schema.LawType != LawTypeAct {
-		t.Errorf("Expected LawType to be '%s', got '%s'", LawTypeAct, schema.LawType)
+	// Unmarshal back to verify structure
+	var unmarshaled Law
+	err = xml.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal marshaled XML: %v", err)
 	}
 
-	if schema.Era != EraShowa {
-		t.Errorf("Expected Era to be '%s', got '%s'", EraShowa, schema.Era)
+	// Verify some key fields
+	if unmarshaled.Era != law.Era {
+		t.Errorf("Era mismatch after round-trip: expected %v, got %v", law.Era, unmarshaled.Era)
+	}
+	if unmarshaled.LawNum != law.LawNum {
+		t.Errorf("LawNum mismatch after round-trip: expected %s, got %s", law.LawNum, unmarshaled.LawNum)
+	}
+	if unmarshaled.LawBody.LawTitle.Content != law.LawBody.LawTitle.Content {
+		t.Errorf("LawTitle content mismatch after round-trip: expected %s, got %s", 
+			law.LawBody.LawTitle.Content, unmarshaled.LawBody.LawTitle.Content)
 	}
 
-	if schema.Year != 27 {
-		t.Errorf("Expected Year to be 27, got %d", schema.Year)
+	t.Logf("Successfully marshaled and unmarshaled Law struct")
+}
+
+func TestWritingModeConstants(t *testing.T) {
+	if WritingModeVertical != "vertical" {
+		t.Errorf("Expected WritingModeVertical to be 'vertical', got %s", WritingModeVertical)
+	}
+	if WritingModeHorizontal != "horizontal" {
+		t.Errorf("Expected WritingModeHorizontal to be 'horizontal', got %s", WritingModeHorizontal)
+	}
+}
+
+func TestEmptyOptionalFields(t *testing.T) {
+	// Test that omitempty works correctly for optional fields
+	law := Law{
+		Era:     EraReiwa,
+		Year:    5,
+		Num:     "1",
+		LawType: LawTypeAct,
+		Lang:    LanguageJapanese,
+		LawNum:  "令和五年法律第一号",
+		LawBody: LawBody{
+			MainProvision: MainProvision{
+				Article: []Article{
+					{
+						Num: "1",
+						Paragraph: []Paragraph{
+							{
+								Num: 1,
+								ParagraphNum: ParagraphNum{
+									Content: "1",
+								},
+								ParagraphSentence: ParagraphSentence{
+									Sentence: []Sentence{
+										{
+											Content: "テスト",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
-	if schema.Num != "231" {
-		t.Errorf("Expected Num to be 231, got %s", schema.Num)
+	data, err := xml.MarshalIndent(law, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal Law: %v", err)
 	}
 
-	if schema.PromulgateMonth != 7 {
-		t.Errorf("Expected PromulgateMonth to be 7, got %d", schema.PromulgateMonth)
+	xmlStr := string(data)
+	
+	// Check that optional attributes are omitted when zero/empty
+	if containsString(xmlStr, "PromulgateMonth=\"0\"") {
+		t.Error("Expected zero PromulgateMonth to be omitted")
 	}
-
-	if schema.PromulgateDay != 15 {
-		t.Errorf("Expected PromulgateDay to be 15, got %d", schema.PromulgateDay)
+	if containsString(xmlStr, "PromulgateDay=\"0\"") {
+		t.Error("Expected zero PromulgateDay to be omitted")
 	}
+	
+	t.Logf("Generated XML (partial): %s", xmlStr[:min(500, len(xmlStr))])
+}
 
-	if schema.Lang != LanguageJapanese {
-		t.Errorf("Expected Lang to be 'ja', got '%s'", schema.Lang)
+func containsString(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && findString(haystack, needle) >= 0
+}
+
+func findString(haystack, needle string) int {
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
 	}
+	return -1
+}
 
-	if schema.LawNum == "" {
-		t.Error("Expected LawNum to be non-empty")
+func min(a, b int) int {
+	if a < b {
+		return a
 	}
-
-	if schema.LawBody.LawTitle.CharData == "" {
-		t.Error("Expected LawTitle to be non-empty")
-	}
-
-	if len(schema.LawBody.MainProvision.Chapter) == 0 {
-		t.Error("Expected at least one Chapter in MainProvision")
-	}
-
-	if len(schema.LawBody.MainProvision.Chapter[0].Article) == 0 {
-		t.Error("Expected at least one Article in the first Chapter")
-	}
-
-	if len(schema.LawBody.MainProvision.Chapter[0].Article[0].Paragraph) == 0 {
-		t.Error("Expected at least one Paragraph in the first Article")
-	}
-
-	if schema.LawBody.MainProvision.Chapter[0].Article[0].Paragraph[0].ParagraphSentence.Sentence[0].CharData == "" {
-		t.Error("Expected ParagraphSentence to have non-empty CharData")
-	}
-
-	if schema.LawNum != "昭和二十七年法律第二百三十一号" {
-		t.Errorf("Expected LawNum to be '昭和二十七年法律第二百三十一号', got '%s'", schema.LawNum)
-	}
-
-	if schema.LawBody.LawTitle.CharData != "航空法" {
-		t.Errorf("Expected LawTitle to be '航空法', got '%s'", schema.LawBody.LawTitle.CharData)
-	}
-
-	if len(schema.LawBody.MainProvision.Chapter) != 13 {
-		t.Errorf("Expected 13 Chapter in MainProvision, got %d", len(schema.LawBody.MainProvision.Chapter))
-	}
-
-	if len(schema.LawBody.MainProvision.Chapter[0].Article) != 2 {
-		t.Errorf("Expected 2 Article in the first Chapter, got %d", len(schema.LawBody.MainProvision.Chapter[0].Article))
-	}
-
-	if len(schema.LawBody.MainProvision.Chapter[0].Article[0].Paragraph) != 1 {
-		t.Errorf("Expected 1 Paragraph in the first Article, got %d", len(schema.LawBody.MainProvision.Chapter[0].Article[0].Paragraph))
-	}
-
-	if schema.LawBody.MainProvision.Chapter[0].Article[0].Paragraph[0].ParagraphSentence.Sentence[0].CharData != "この法律は、国際民間航空条約の規定並びに同条約の附属書として採択された標準、方式及び手続に準拠して、航空機の航行の安全及び航空機の航行に起因する障害の防止を図るための方法を定め、航空機を運航して営む事業の適正かつ合理的な運営を確保して輸送の安全を確保するとともにその利用者の利便の増進を図り、並びに航空の脱炭素化を推進するための措置を講じ、あわせて無人航空機の飛行における遵守事項等を定めてその飛行の安全の確保を図ることにより、航空の発達を図り、もつて公共の福祉を増進することを目的とする。" {
-		t.Errorf("Expected ParagraphSentence to have 'この法律は、(snip)', got '%s'", schema.LawBody.MainProvision.Chapter[0].Article[0].Paragraph[0].ParagraphSentence.Sentence[0].CharData)
-	}
-
-	// Add more assertions based on the expected structure of the schema
+	return b
 }


### PR DESCRIPTION
This commit introduces Claude Code configuration and significantly expands the Japanese law XML schema implementation.

**Claude Code Settings**
- Add .claude/settings.local.json with permissions for e-gov.go.jp web fetching, curl commands, and Go test execution

**Schema Improvements**
- Add comprehensive XML struct definitions for all Japanese law document elements
- Implement proper XML namespace handling with xml.Name
- Add support for nested law structures including parts, chapters, sections, subsections, and divisions
- Include definitions for amendments, supplementary provisions, appendices, and various table/figure structures
- Add inline text formatting elements (Ruby, Sup, Sub, Line)
- Implement sentence structure with proper WritingMode attribute support
- Add complete item hierarchy from Item through Subitem10
- Include specialized structures for tables, figures, styles, and formatting

The expanded schema now properly represents the full complexity of Japanese legal documents as defined in the official e-Gov XML format.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
